### PR TITLE
Bumped sv-parser to 0.12.1 and added --allow_incomplete to arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ description = "Determines the modules declared and instantiated in SystemVerilog
 edition = "2018"
 
 [dependencies]
-sv-parser = "0.8.3"
-sv-parser-error = "0.8.3"
-sv-parser-syntaxtree = "0.8.3"
+sv-parser = "0.12.1"
+sv-parser-error = "0.12.1"
+sv-parser-syntaxtree = "0.12.1"
 structopt = "0.3.20"
 enquote = "1.0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,13 +34,17 @@ struct Opt {
     #[structopt(long = "include-whitespace")]
     pub include_whitespace: bool,
  
-	/// Show the macro definitions after processing each file
-	#[structopt(long = "show-macro-defs")]
-	pub show_macro_defs: bool,
+    /// Show the macro definitions after processing each file
+    #[structopt(long = "show-macro-defs")]
+    pub show_macro_defs: bool,
 
     /// Treat each file as completely separate, not updating define variables after each file
     #[structopt(long = "separate")]
-    pub separate: bool
+    pub separate: bool,
+
+    /// Allow incomplete
+    #[structopt(long = "allow_incomplete")]
+    pub allow_incomplete: bool
 }
 
 fn main() {
@@ -74,7 +78,7 @@ fn run_opt(
     // parse files
     println!("files:");
     for path in &opt.files {
-        match parse_sv(&path, &defines, &opt.includes, opt.ignore_include) {
+        match parse_sv(&path, &defines, &opt.includes, opt.ignore_include, opt.allow_incomplete) {
             Ok((syntax_tree, new_defines)) => {
 				println!("  - file_name: {}", escape_str(path.to_str().unwrap()));
 				if !opt.full_tree {

--- a/src/main.rs
+++ b/src/main.rs
@@ -501,7 +501,8 @@ mod tests {
 			include_whitespace: false,
 			ignore_include: false,
 			separate: false,
-			show_macro_defs: false
+			show_macro_defs: false,
+			allow_incomplete: false
 		};
 		expect_pass(&opt);
     }
@@ -516,7 +517,8 @@ mod tests {
 			include_whitespace: false,
 			ignore_include: false,
 			separate: false,
-			show_macro_defs: false
+			show_macro_defs: false,
+			allow_incomplete: false
 		};
 		expect_fail(&opt);
     }
@@ -531,7 +533,8 @@ mod tests {
 			include_whitespace: false,
 			ignore_include: false,
 			separate: false,
-			show_macro_defs: false
+			show_macro_defs: false,
+			allow_incomplete: false
 		};
 		expect_pass(&opt);
     }
@@ -547,7 +550,8 @@ mod tests {
 			include_whitespace: false,
 			ignore_include: false,
 			separate: false,
-			show_macro_defs: true
+			show_macro_defs: true,
+			allow_incomplete: false
 		};
 		expect_pass(&opt);
     }
@@ -562,7 +566,8 @@ mod tests {
 			include_whitespace: false,
 			ignore_include: false,
 			separate: false,
-			show_macro_defs: false
+			show_macro_defs: false,
+			allow_incomplete: false
 		};
 		expect_pass(&opt);
     }
@@ -577,7 +582,8 @@ mod tests {
 			include_whitespace: false,
 			ignore_include: false,
 			separate: false,
-			show_macro_defs: false
+			show_macro_defs: false,
+			allow_incomplete: false
 		};
 		expect_pass(&opt);
     }
@@ -592,7 +598,8 @@ mod tests {
 			include_whitespace: false,
 			ignore_include: false,
 			separate: false,
-			show_macro_defs: false
+			show_macro_defs: false,
+			allow_incomplete: false
 		};
 		expect_pass(&opt);
     }
@@ -607,7 +614,8 @@ mod tests {
 			include_whitespace: false,
 			ignore_include: false,
 			separate: false,
-			show_macro_defs: false
+			show_macro_defs: false,
+			allow_incomplete: false
 		};
 		expect_pass(&opt);
     }
@@ -622,7 +630,8 @@ mod tests {
 			include_whitespace: false,
 			ignore_include: false,
 			separate: false,
-			show_macro_defs: false
+			show_macro_defs: false,
+			allow_incomplete: false
 		};
 		expect_pass(&opt);
     }
@@ -642,7 +651,8 @@ mod tests {
 			include_whitespace: false,
 			ignore_include: false,
 			separate: false,
-			show_macro_defs: false
+			show_macro_defs: false,
+			allow_incomplete: false
 		};
 		expect_pass(&opt);
     }


### PR DESCRIPTION
Since the sv-parser version has ages quite a bit and there are recent fixes I needed, I patched svinst to bump to the latest sv-parser version 0.12.1.